### PR TITLE
Fixed error when undistorting images from a C920 WebCam

### DIFF
--- a/src/FrameHelper.cpp
+++ b/src/FrameHelper.cpp
@@ -189,8 +189,8 @@ namespace frame_helper
         case COLOR + UNDISTORT:
             dst.attributes.clear();
             frame_buffer2.init(dst,false);
-            convertColor(src,frame_buffer2);
-            undistort(frame_buffer2,dst);
+            undistort(src,frame_buffer2);
+            convertColor(frame_buffer2,dst);
             break;
         case RESIZE + COLOR + UNDISTORT:
             dst.attributes.clear();


### PR DESCRIPTION
This commit fixes a segfault when using the undistort function
for a Logitech C920 Webcam. I found it on our Robot and
have no idea, if it is a proper fix.
Greetings
   Janosch
