### PR TITLE
fixed image undistortion when MODE_BAYER_GRBG to MODE_RGB

### DIFF
--- a/src/FrameHelper.cpp
+++ b/src/FrameHelper.cpp
@@ -219,7 +219,7 @@ namespace frame_helper
             base::samples::frame::Frame &dst)
     {
         // check if format is supported
-        if(src.getFrameMode() != MODE_RGB && src.getFrameMode() != MODE_GRAYSCALE )
+        if(src.getFrameMode() == MODE_UNDEFINED )
             throw std::runtime_error("FrameHelper::undistort: frame mode is not supported!");
 
 	// avoid calling undistort twice

--- a/src/FrameHelper.cpp
+++ b/src/FrameHelper.cpp
@@ -219,7 +219,7 @@ namespace frame_helper
             base::samples::frame::Frame &dst)
     {
         // check if format is supported
-        if(src.getFrameMode() == MODE_UNDEFINED )
+        if(src.getFrameMode() != MODE_RGB && src.getFrameMode() != MODE_GRAYSCALE )
             throw std::runtime_error("FrameHelper::undistort: frame mode is not supported!");
 
 	// avoid calling undistort twice

--- a/src/FrameHelper.cpp
+++ b/src/FrameHelper.cpp
@@ -189,8 +189,8 @@ namespace frame_helper
         case COLOR + UNDISTORT:
             dst.attributes.clear();
             frame_buffer2.init(dst,false);
-            undistort(src,frame_buffer2);
-            convertColor(frame_buffer2,dst);
+            convertColor(src, frame_buffer2);
+            undistort(frame_buffer2,dst);
             break;
         case RESIZE + COLOR + UNDISTORT:
             dst.attributes.clear();


### PR DESCRIPTION
This PR has intentionally two commits.
**First** to fix the distortion, **second** to fix the runtime error exception.
I am open to suggestion/feedback in the second commit. Leave it as only RGB or GRAYSCALE does not seem to be a solution (no working for bb2 cameras). 