### PR TITLE
Functions to load raw JPEG images without decompressing from file or from memory.

### DIFF
--- a/src/FrameHelper.cpp
+++ b/src/FrameHelper.cpp
@@ -1133,4 +1133,16 @@ namespace frame_helper
         cv::Mat mat = cv::imread(filename.c_str());
         copyMatToFrame(mat,frame);
     }
+
+    void FrameHelper::loadFrameJPEG(const std::string &filename, base::samples::frame::Frame &frame)
+    {
+        conversion::JpegConversion::loadJpeg(filename, 0, 0, frame);
+    }
+    void FrameHelper::loadFrameJPEG(const uint8_t* src, size_t size, base::samples::frame::Frame &frame)
+    {
+        frame.init(0, 0, 8, MODE_JPEG);
+        frame.setImage(src, size);
+        frame.size = conversion::JpegConversion::getSize(src, size);
+    }
+
 }

--- a/src/FrameHelper.h
+++ b/src/FrameHelper.h
@@ -157,6 +157,16 @@ namespace frame_helper
     
             void saveFrame(const std::string &filename,base::samples::frame::Frame const &frame);
             void loadFrame(const std::string &filename,base::samples::frame::Frame &frame);
+
+            /**
+             * Loads a JPEG image from file without decompressing it (can be useful if frame is directly transmitted afterwards)
+             */
+            static void loadFrameJPEG(const std::string &filename, base::samples::frame::Frame &frame);
+            /**
+             * Loads JPEG image from memory without decompressing it.
+             * If frame.size=={0,0} before calling this function, it is set automatically based on the JPEG header.
+             */
+            static void loadFrameJPEG(const uint8_t* src, size_t size, base::samples::frame::Frame &frame);
     };
 };
 #endif // FRAMEHELPER_H

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -5,7 +5,6 @@
 #define BOOST_TEST_MODULE "frame_helper"
 #define BOOST_AUTO_TEST_MAIN
 #include "../src/FrameHelper.h"
-#include <boost/test/auto_unit_test.hpp>
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <opencv2/highgui/highgui.hpp>
@@ -37,8 +36,9 @@ bool compareImages(cv::Mat src1, cv::Mat src2)
 
 BOOST_AUTO_TEST_CASE(convert_image)
 {
+    std::string const filename = TEST_SRC_DIR + string("/test.jpg");
     // load image
-    cv::Mat original = cv::imread(TEST_SRC_DIR + string("/test.jpg"));
+    cv::Mat original = cv::imread(filename);
     BOOST_CHECK(NULL != original.data);
 
     // check if convertion is working
@@ -79,6 +79,18 @@ BOOST_AUTO_TEST_CASE(convert_image)
     grayscale_fs["Image"] >> grayscale_sheet;
     grayscale_fs.release();
     BOOST_CHECK(compareImages(grayscale_sheet, gray));
+
+    Frame frame_jpeg;
+    FrameHelper::loadFrameJPEG(filename, frame_jpeg);
+    BOOST_CHECK(frame_jpeg.size == frame.size);
+    BOOST_CHECK_EQUAL(frame_jpeg.frame_mode, MODE_JPEG);
+    frame_helper.convertColor(frame, frame_jpeg);
+
+    Frame frame_jpeg_dataonly;
+    FrameHelper::loadFrameJPEG(frame_jpeg.image.data(), frame_jpeg.image.size(), frame_jpeg_dataonly);
+    frame_jpeg_dataonly.setImage(frame_jpeg.image);
+    BOOST_CHECK(frame_jpeg_dataonly.size == frame.size);
+    BOOST_CHECK_EQUAL(frame_jpeg_dataonly.frame_mode, MODE_JPEG);
 }
 
 BOOST_AUTO_TEST_CASE(load_calibration_file)

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -91,6 +91,13 @@ BOOST_AUTO_TEST_CASE(convert_image)
     frame_jpeg_dataonly.setImage(frame_jpeg.image);
     BOOST_CHECK(frame_jpeg_dataonly.size == frame.size);
     BOOST_CHECK_EQUAL(frame_jpeg_dataonly.frame_mode, MODE_JPEG);
+
+    Frame decompressed(original.cols, original.rows, 8, MODE_BGR, -1);
+    frame_helper.convertColor(frame_jpeg, decompressed);
+
+    cv::Mat converted_decompressed = FrameHelper::convertToCvMat(decompressed);
+    BOOST_CHECK(compareImages(original, converted_decompressed));
+
 }
 
 BOOST_AUTO_TEST_CASE(load_calibration_file)


### PR DESCRIPTION
This is an alternative to https://github.com/rock-core/base-types/pull/165
It depends on https://github.com/rock-core/perception-jpeg_conversion/pull/3 getting merged first